### PR TITLE
make excon-hypermedia work with "application/json"

### DIFF
--- a/lib/excon/hypermedia/response.rb
+++ b/lib/excon/hypermedia/response.rb
@@ -37,7 +37,7 @@ module Excon
       end
 
       def body_to_hash
-        content_type.include?('application/hal+json') ? JSON.parse(response.body) : {}
+        (content_type =~ %r{application/(hal\+)?json}).nil? ? {} : JSON.parse(response.body)
       end
 
       def content_type

--- a/test/excon/integration_test.rb
+++ b/test/excon/integration_test.rb
@@ -92,6 +92,13 @@ module Excon
       assert_equal data(:front_wheel)['position'], response.resource._embedded.wheels.first.position
     end
 
+    def test_request_with_json_content_type
+      api      = Excon.get('https://www.example.org/api_v2.json', hypermedia: true)
+      response = api.rel('product', expand: { uid: 'bicycle' }).get
+
+      assert response.body.include?('https://www.example.org/product/bicycle')
+    end
+
     def teardown
       Excon.stubs.clear
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,7 @@ module Excon
       Excon.stub({ method: :get, path: '/product/bicycle/wheels/rear' }, response.merge(body: rear_wheel_body))
       Excon.stub({ method: :get, path: '/product/pump' }, response.merge(body: pump_body))
       Excon.stub({ method: :get, path: '/product/handlebar' }, response.merge(body: handlebar_body))
+      Excon.stub({ method: :get, path: '/api_v2.json' }, body: api_body, headers: { 'Content-Type' => 'application/json' })
     end
 
     def teardown
@@ -92,7 +93,9 @@ module Excon
       <<~EOF
         {
           "_links": {
-            "self": "https://www.example.org/product/handlebar"
+            "self": {
+              "href": "https://www.example.org/product/handlebar"
+            }
           },
           "material": "Carbon fiber",
           "reach": "75mm",
@@ -105,7 +108,9 @@ module Excon
       <<~EOF
         {
           "_links": {
-            "self": "https://www.example.org/product/pump"
+            "self": {
+              "href": "https://www.example.org/product/pump"
+            }
           },
           "weight": "2kg",
           "type": "Floor Pump",


### PR DESCRIPTION
When explicitly setting `hypermedia: true`, and the returned
Content-Type is set to `application/json`, the body should be parsed
using `JSON.parse`.