### PR TITLE
Set `private` on it's own line.

### DIFF
--- a/lib/excon/hypermedia/link_object.rb
+++ b/lib/excon/hypermedia/link_object.rb
@@ -145,7 +145,9 @@ module Excon
         Excon.new(href, params)
       end
 
-      private def property(value)
+      private
+
+      def property(value)
         value
       end
     end

--- a/lib/excon/hypermedia/resource_object/embedded.rb
+++ b/lib/excon/hypermedia/resource_object/embedded.rb
@@ -10,7 +10,9 @@ module Excon
       class Embedded
         include Collection
 
-        private def property(value)
+        private
+
+        def property(value)
           if value.respond_to?(:to_ary)
             value.map { |v| ResourceObject.new(v) }
           else

--- a/lib/excon/hypermedia/resource_object/links.rb
+++ b/lib/excon/hypermedia/resource_object/links.rb
@@ -10,7 +10,9 @@ module Excon
       class Links
         include Collection
 
-        private def property(value)
+        private
+
+        def property(value)
           value.respond_to?(:to_ary) ? value.map { |v| LinkObject.new(v) } : LinkObject.new(value)
         end
       end


### PR DESCRIPTION
I'm currently working on a gem that will be used in a few legacy projects running Ruby 2.0, this change should help towards making this gem compatible as well.