### PR TITLE
Ignore case when finding content type

### DIFF
--- a/lib/excon/hypermedia/middleware.rb
+++ b/lib/excon/hypermedia/middleware.rb
@@ -36,7 +36,9 @@ module Excon
       end
 
       def response_call(datum)
-        return super unless (content_type = datum.dig(:response, :headers, 'Content-Type').to_s)
+        return super unless (headers = datum.dig(:response, :headers))
+        return super unless (match = headers.find { |k, v| k.downcase == 'content-type' })
+        content_type = match[1].to_s
 
         datum[:response][:hypermedia] = if datum[:hypermedia].nil?
           content_type.include?('hal+json')

--- a/test/excon/middleware_test.rb
+++ b/test/excon/middleware_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/LineLength
+
+require_relative '../test_helper'
+
+module Excon
+  class MiddlewareTest < Minitest::Test
+    def setup
+      Excon.defaults[:mock] = true
+      Excon.stub(
+        { :path => '/lowercase-content-type' },
+        {
+          headers: { 'content-type' => 'application/hal+json' },
+          body:    '{}',
+          status:  200
+        }
+      )
+      Excon.stub(
+        { :path => '/uppercase-content-type' },
+        {
+          headers: { 'Content-Type' => 'application/hal+json' },
+          body:    '{}',
+          status:  200
+        }
+      )
+    end
+
+    def test_request_with_lowercase_content_type
+      test = Excon.get(
+        'http://example.com',
+        path: '/lowercase-content-type',
+        middlewares: Excon.defaults[:middlewares] + [Excon::HyperMedia::Middleware]
+      )
+
+      assert test.data[:hypermedia]
+    end
+
+    def test_request_with_uppercase_content_type
+      test = Excon.get(
+        'http://example.com',
+        path: '/uppercase-content-type',
+        middlewares: Excon.defaults[:middlewares] + [Excon::HyperMedia::Middleware]
+      )
+
+      assert test.data[:hypermedia]
+    end
+
+    def teardown
+      Excon.stubs.clear
+      Excon.defaults[:mock] = false
+    end
+  end
+end
+
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/LineLength


### PR DESCRIPTION
Find content type in header hash by performing a case insensitive comparison.

Headers field names are case insensitive as per the [HTTP/1.1](https://tools.ietf.org/html/rfc7230#section-3.2) specification.