### PR TITLE
Allow raw data access on ResourceObject

### DIFF
--- a/lib/excon/hypermedia/resource_object.rb
+++ b/lib/excon/hypermedia/resource_object.rb
@@ -13,6 +13,8 @@ module Excon
     class ResourceObject
       RESERVED_PROPERTIES = %w[_links _embedded].freeze
 
+      attr_reader :data
+
       def initialize(data)
         @data = data
       end

--- a/test/excon/resource_object_test.rb
+++ b/test/excon/resource_object_test.rb
@@ -31,7 +31,7 @@ module Excon
     end
 
     def test_resource
-      assert_equal data, resource.instance_variable_get(:@data)
+      assert_equal data, resource.data
     end
 
     def test_links


### PR DESCRIPTION
When processing large JSON responses, the repeated instantiation of objects makes this processing extremely slow. Allowing raw data access allows much faster reading of responses.

These changes allow users to skip convenience methods when all they need is the data itself.

----

We experienced a decrease of about 3000% in processing time when using raw data access. In our case we're using excon-hypermedia to "get to the data" by following links, but then we get to a pretty heavy endpoint where all we need is the data.