### PR TITLE
Use `valid_parameter_keys` middleware interface

### DIFF
--- a/lib/excon/hypermedia/middleware.rb
+++ b/lib/excon/hypermedia/middleware.rb
@@ -11,9 +11,6 @@ Excon.defaults[:middlewares].unshift(Excon::Addressable::Middleware)
 # creating a request, or connection object. Excon does not enforce this yet, but
 # it does print a warning, so this makes things future-proof.
 module Excon
-  VALID_REQUEST_KEYS.push(:hcp, :embedded, :hypermedia)
-  VALID_CONNECTION_KEYS.push(:hcp, :embedded, :hypermedia)
-
   module HyperMedia
     # Middleware
     #
@@ -24,6 +21,10 @@ module Excon
     # will be left alone by this middleware.
     #
     class Middleware < Excon::Middleware::Base
+      def self.valid_parameter_keys
+        %i[hcp embedded hypermedia]
+      end
+      
       def request_call(datum)
         # if `hcp` is enabled, insert the `HypertextCachePattern` middleware in
         # the middleware stack right after this one.


### PR DESCRIPTION
As per the recent `0.111.0` Excon release, the `VALID_REQUEST_KEYS` array constant is frozen.

Same for the `excon-addressable` dependency (https://github.com/blendle/excon-addressable/pull/5).
